### PR TITLE
2.18 系でも使える新しい記法で書くようにした

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     browser: true
   },
   rules: {
-    'ember/new-module-imports': 'off'
   },
   overrides: [
     // node files

--- a/addon/components/mg-button.js
+++ b/addon/components/mg-button.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/mg-button';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: 'button',
   classNames: ['btn'],

--- a/addon/components/mg-checkbox.js
+++ b/addon/components/mg-checkbox.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['c-checkbox'],
   classNameBindings: ['checked:c-checkbox--checked'],
 

--- a/addon/components/mg-toggle-switch.js
+++ b/addon/components/mg-toggle-switch.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/mg-toggle-switch';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['c-toggle-switch'],
   classNameBindings: ['enabled:c-toggle-switch--enabled'],


### PR DESCRIPTION
Gem のサポートをやめたので古い記法にする必要がなくなったため、
新しい記法に戻しました。